### PR TITLE
Add flags for using existing job reservation, and provisioning a machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
 [![Build Status](https://travis-ci.org/Spirals-Team/docker-machine-driver-g5k.svg)](https://travis-ci.org/Spirals-Team/docker-machine-driver-g5k)
 
 # docker-machine-driver-g5k
-A Docker Machine driver for the Grid5000 testbed infrastructure. It will provision a Docker machine on a node of the Grid5000.
+A Docker Machine driver for the Grid5000 testbed infrastructure. It can be used to provision a Docker machine on a node of the Grid5000 infrastructure.
 
 ## Requirements
 * [Docker](https://www.docker.com/products/overview#/install_the_platform)
-* [Docker Machine](https://docs.docker.com/machine/install-machine/)
+* [Docker Machine](https://docs.docker.com/machine/install-machine)
 * [Go tools](https://golang.org/doc/install)
 
 You need a Grid5000 account to use this driver. See [this page](https://www.grid5000.fr/mediawiki/index.php/Grid5000:Get_an_account) to create an account.
 
 ## Installation from GitHub releases
-Binary releases are available for Linux, MacOS and Windows on the [releases page](https://github.com/Spirals-Team/docker-machine-driver-g5k/releases).  
-You can use the usual commands to install or upgrade the driver :
-
+Binary releases are available for Linux, MacOS and Windows from the [releases page](https://github.com/Spirals-Team/docker-machine-driver-g5k/releases).
+You can use the following commands to install or upgrade the driver:
 ```bash
 # download the binary for your OS
 sudo curl -L -o /usr/local/bin/docker-machine-driver-g5k "<link to release>"
@@ -28,13 +27,11 @@ sudo chmod +x /usr/local/bin/docker-machine-driver-g5k
 To use the Go tools, you need to set your [GOPATH](https://golang.org/doc/code.html#GOPATH) variable environment.
 
 To get the code and compile the binary, run:
-
 ```bash
 go get -u github.com/Spirals-Team/docker-machine-driver-g5k
 ```
 
 Then, either put the driver in a directory filled in your PATH environment variable, or run:
-
 ```bash
 export PATH=$PATH:$GOPATH/bin
 ```
@@ -44,10 +41,10 @@ export PATH=$PATH:$GOPATH/bin
 ### VPN
 You need to be connected to the Grid5000 VPN to create and access your Docker node.  
 Do not forget to configure your DNS or use OpenVPN DNS auto-configuration.  
-Please follow the instructions on the [Grid5000 Wiki](https://www.grid5000.fr/mediawiki/index.php/VPN).
+Please follow the instructions from the [Grid5000 Wiki](https://www.grid5000.fr/mediawiki/index.php/VPN).
 
 ### Driver-specific options
-The driver needs a few options to create a machine. Here is a list of options:
+The driver needs a few options to create a machine. Here is a list of the supported options:
 
 |            Option            |                       Description                       |     Default value     |  Required  |
 |------------------------------|---------------------------------------------------------|-----------------------|------------|
@@ -59,13 +56,12 @@ The driver needs a few options to create a machine. Here is a list of options:
 | `--g5k-ssh-public-key`       | Path of your ssh public key                             | "< private-key >.pub" | No         |
 | `--g5k-image`                | Name of the image to deploy                             | "jessie-x64-min"      | No         |
 | `--g5k-resource-properties`  | Resource selection with OAR properties (SQL format)     |                       | No         |
-| `--g5k-use-job-reservation`  | job ID to use (need to be an already existing job ID)   |                       | No         |
+| `--g5k-use-job-reservation`  | Job ID to use (need to be an already existing job ID)   |                       | No         |
 | `--g5k-host-to-provision`    | Host to provision (host need to be already deployed)    |                       | No         |
 
 #### Resource properties
 You can use [OAR properties](http://oar.imag.fr/docs/2.5/user/usecases.html#using-properties) to only select a node that matches your hardware requirements.  
-If you give incorrect properties or no resource matches your request, you will get this error :
-
+If you give incorrect properties or no resource matches your request, you will get this error:
 ```bash
 Error with pre-create check: "[G5K_api] request failed: 400 Bad Request."
 ```
@@ -73,8 +69,7 @@ Error with pre-create check: "[G5K_api] request failed: 400 Bad Request."
 More informations about usage of OAR properties are available on the [Grid5000 Wiki](https://www.grid5000.fr/mediawiki/index.php/Advanced_OAR#Other_examples_using_properties).
 
 ### Provisioning examples
-An example of node provisioning :
-
+An example of node provisioning:
 ```bash
 docker-machine create -d g5k \
 --g5k-username user \
@@ -84,8 +79,7 @@ docker-machine create -d g5k \
 test-node
 ```
 
-An example with resource properties (node in cluster 'chimint' with more thant 8Gb of ram and at least 4 CPU cores) :
-
+An example with resource properties (node in cluster `chimint` with more thant 8GB of RAM and at least 4 CPU cores):
 ```bash
 docker-machine create -d g5k \
 --g5k-username user \
@@ -96,8 +90,7 @@ docker-machine create -d g5k \
 test-node
 ```
 
-An example using an existing oarsub job ID and a host already deployed with kadeploy3 :
-
+An example using an existing oarsub job ID and a host already deployed with kadeploy3:
 ```bash
 docker-machine create -d g5k \
 --g5k-username user \

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You need to be connected to the Grid5000 VPN to create and access your Docker no
 Do not forget to configure your DNS or use OpenVPN DNS auto-configuration.  
 Please follow the instructions on the [Grid5000 Wiki](https://www.grid5000.fr/mediawiki/index.php/VPN).
 
-### Driver-specific Options
+### Driver-specific options
 The driver needs a few options to create a machine. Here is a list of options:
 
 |            Option            |                       Description                       |     Default value     |  Required  |
@@ -59,6 +59,8 @@ The driver needs a few options to create a machine. Here is a list of options:
 | `--g5k-ssh-public-key`       | Path of your ssh public key                             | "< private-key >.pub" | No         |
 | `--g5k-image`                | Name of the image to deploy                             | "jessie-x64-min"      | No         |
 | `--g5k-resource-properties`  | Resource selection with OAR properties (SQL format)     |                       | No         |
+| `--g5k-use-job-reservation`  | job ID to use (need to be an already existing job ID)   |                       | No         |
+| `--g5k-host-to-provision`    | Host to provision (host need to be already deployed)    |                       | No         |
 
 #### Resource properties
 You can use [OAR properties](http://oar.imag.fr/docs/2.5/user/usecases.html#using-properties) to only select a node that matches your hardware requirements.  
@@ -70,7 +72,7 @@ Error with pre-create check: "[G5K_api] request failed: 400 Bad Request."
 
 More informations about usage of OAR properties are available on the [Grid5000 Wiki](https://www.grid5000.fr/mediawiki/index.php/Advanced_OAR#Other_examples_using_properties).
 
-### Provisioning Examples
+### Provisioning examples
 An example of node provisioning :
 
 ```bash
@@ -82,7 +84,7 @@ docker-machine create -d g5k \
 test-node
 ```
 
-An example with resource properties (node in cluster 'chimint' with more thant 8Gb of ram and at least 4 CPU cores)
+An example with resource properties (node in cluster 'chimint' with more thant 8Gb of ram and at least 4 CPU cores) :
 
 ```bash
 docker-machine create -d g5k \
@@ -93,3 +95,16 @@ docker-machine create -d g5k \
 --g5k-resource-properties "cluster = 'chimint' and memnode > 8192 and cpucore >= 4" \
 test-node
 ```
+
+An example using an existing oarsub job ID and a host already deployed with kadeploy3 :
+
+```bash
+docker-machine create -d g5k \
+--g5k-username user \
+--g5k-password ******** \
+--g5k-site lille \
+--g5k-ssh-private-key ~/.ssh/g5k-key \
+--g5k-use-job-reservation 1234567 \
+--g5k-host-to-provision "chinqchint-xx.lille.grid5000.fr" \
+test-node
+``` 


### PR DESCRIPTION
PR overview :
- Add a command line flag `--g5k-use-job-reservation` to specify the job reservation to use (skipping the job reservation part) ;
- Add a command line flag `--g5k-host-to-provision` to specify the host to provision docker on (skipping the job deployment part, so the host need to be already deployed) ;
- Update README.
