### PR TITLE
Remove unused code in API client

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -51,7 +51,7 @@ func (d *Driver) DriverName() string {
 
 func (d *Driver) getAPI() *api.Api {
 	if d.Api == nil {
-		d.Api = api.NewApi(d.G5kUsername, d.G5kPassword, d.G5kSite, d.G5kImage)
+		d.Api = api.NewApi(d.G5kUsername, d.G5kPassword, d.G5kSite)
 	}
 	return d.Api
 }


### PR DESCRIPTION
PR overview:

- Remove unused function 'GetSiteClusters' ;
- Remove unused 'image' / 'Environment' parameters (Nothing to do there, only used in Deployment part) ;
- Remove the unused parameter 'image' of the function 'NewApi' in 'driver'.