### PR TITLE
SSH key pair auto-generation, config with environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ docker-machine create -d g5k \
 test-node
 ```
 
+An example of node provisioning using environment variables:
+```bash
+export G5K_USERNAME="user"
+export G5K_PASSWORD="********"
+export G5K_SITE="lille"
+docker-machine create -d g5k test-node
+```
+
 An example with resource properties (node in cluster `chimint` with more thant 8GB of RAM and at least 4 CPU cores):
 ```bash
 docker-machine create -d g5k \

--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ The driver needs a few options to create a machine. Here is a list of the suppor
 | `--g5k-password`             | Your Grid5000 account password                          |                       | Yes        |
 | `--g5k-site`                 | Site to reserve the resources on                        |                       | Yes        |
 | `--g5k-walltime`             | Timelife of the machine                                 | "1:00:00"             | No         |
-| `--g5k-ssh-private-key`      | Path of your ssh private key                            | "~/.ssh/id_rsa"       | No         |
-| `--g5k-ssh-public-key`       | Path of your ssh public key                             | "< private-key >.pub" | No         |
 | `--g5k-image`                | Name of the image to deploy                             | "jessie-x64-min"      | No         |
 | `--g5k-resource-properties`  | Resource selection with OAR properties (SQL format)     |                       | No         |
 | `--g5k-use-job-reservation`  | Job ID to use (need to be an already existing job ID)   |                       | No         |
@@ -72,20 +70,18 @@ More informations about usage of OAR properties are available on the [Grid5000 W
 An example of node provisioning:
 ```bash
 docker-machine create -d g5k \
---g5k-username user \
---g5k-password ******** \
---g5k-site lille \
---g5k-ssh-private-key ~/.ssh/g5k-key \
+--g5k-username "user" \
+--g5k-password "********" \
+--g5k-site "lille" \
 test-node
 ```
 
 An example with resource properties (node in cluster `chimint` with more thant 8GB of RAM and at least 4 CPU cores):
 ```bash
 docker-machine create -d g5k \
---g5k-username user \
---g5k-password ******** \
---g5k-site lille \
---g5k-ssh-private-key ~/.ssh/g5k-key \
+--g5k-username "user" \
+--g5k-password "********" \
+--g5k-site "lille" \
 --g5k-resource-properties "cluster = 'chimint' and memnode > 8192 and cpucore >= 4" \
 test-node
 ```
@@ -93,10 +89,9 @@ test-node
 An example using an existing oarsub job ID and a host already deployed with kadeploy3:
 ```bash
 docker-machine create -d g5k \
---g5k-username user \
---g5k-password ******** \
---g5k-site lille \
---g5k-ssh-private-key ~/.ssh/g5k-key \
+--g5k-username "user" \
+--g5k-password "********" \
+--g5k-site "lille" \
 --g5k-use-job-reservation 1234567 \
 --g5k-host-to-provision "chinqchint-xx.lille.grid5000.fr" \
 test-node

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -50,62 +50,72 @@ func (d *Driver) DriverName() string {
 func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	return []mcnflag.Flag{
 		mcnflag.StringFlag{
-			Name:  "g5k-username",
-			Usage: "Your Grid5000 account username",
-			Value: "",
+			EnvVar: "G5K_USERNAME",
+			Name:   "g5k-username",
+			Usage:  "Your Grid5000 account username",
+			Value:  "",
 		},
 
 		mcnflag.StringFlag{
-			Name:  "g5k-password",
-			Usage: "Your Grid5000 account password",
-			Value: "",
+			EnvVar: "G5K_PASSWORD",
+			Name:   "g5k-password",
+			Usage:  "Your Grid5000 account password",
+			Value:  "",
 		},
 
 		mcnflag.StringFlag{
-			Name:  "g5k-site",
-			Usage: "Site to reserve the resources on",
-			Value: "",
+			EnvVar: "G5K_SITE",
+			Name:   "g5k-site",
+			Usage:  "Site to reserve the resources on",
+			Value:  "",
 		},
 
 		mcnflag.StringFlag{
-			Name:  "g5k-walltime",
-			Usage: "Machine's lifetime (HH:MM:SS)",
-			Value: "1:00:00",
+			EnvVar: "G5K_WALLTIME",
+			Name:   "g5k-walltime",
+			Usage:  "Machine's lifetime (HH:MM:SS)",
+			Value:  "1:00:00",
 		},
 
 		mcnflag.StringFlag{
-			Name:  "g5k-ssh-private-key",
-			Usage: "Path of your ssh private key (Only RSA keys in PEM format are supported)",
-			Value: "",
+			EnvVar: "G5K_SSH_PRIVATE_KEY",
+			Name:   "g5k-ssh-private-key",
+			Usage:  "Path of your ssh private key (Only RSA keys in PEM format are supported)",
+			Value:  "",
 		},
 
 		mcnflag.StringFlag{
-			Name:  "g5k-ssh-public-key",
-			Usage: "Path of your ssh public key (Only RSA keys in AuthorizedKey format are supported) ",
-			Value: "",
+			EnvVar: "G5K_SSH_PUBLIC_KEY",
+			Name:   "g5k-ssh-public-key",
+			Usage:  "Path of your ssh public key (Only RSA keys in AuthorizedKey format are supported) ",
+			Value:  "",
 		},
 
 		mcnflag.StringFlag{
-			Name:  "g5k-image",
-			Usage: "Name of the image to deploy",
-			Value: "jessie-x64-min",
+			EnvVar: "G5K_IMAGE",
+			Name:   "g5k-image",
+			Usage:  "Name of the image to deploy",
+			Value:  "jessie-x64-min",
 		},
 
 		mcnflag.StringFlag{
-			Name:  "g5k-resource-properties",
-			Usage: "Resource selection with OAR properties (SQL format)",
-			Value: "",
+			EnvVar: "G5K_RESOURCE_PROPERTIES",
+			Name:   "g5k-resource-properties",
+			Usage:  "Resource selection with OAR properties (SQL format)",
+			Value:  "",
 		},
 
 		mcnflag.IntFlag{
-			Name:  "g5k-use-job-reservation",
-			Usage: "job ID to use (need to be an already existing job ID, because job reservation will be skipped)",
+			EnvVar: "G5K_USE_JOB_RESERVATION",
+			Name:   "g5k-use-job-reservation",
+			Usage:  "job ID to use (need to be an already existing job ID, because job reservation will be skipped)",
 		},
 
 		mcnflag.StringFlag{
-			Name:  "g5k-host-to-provision",
-			Usage: "Host to provision (host need to be already deployed, because deployment step will be skipped)",
-			Value: "",
+			EnvVar: "G5K_HOST_TO_PROVISION",
+			Name:   "g5k-host-to-provision",
+			Usage:  "Host to provision (host need to be already deployed, because deployment step will be skipped)",
+			Value:  "",
 		},
 	}
 }

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -23,8 +23,6 @@ type Driver struct {
 	G5kPassword           string
 	G5kSite               string
 	G5kWalltime           string
-	G5kSSHPrivateKeyPath  string
-	G5kSSHPublicKeyPath   string
 	G5kImage              string
 	G5kResourceProperties string
 	G5kHostToProvision    string
@@ -78,20 +76,6 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		},
 
 		mcnflag.StringFlag{
-			EnvVar: "G5K_SSH_PRIVATE_KEY",
-			Name:   "g5k-ssh-private-key",
-			Usage:  "Path of your ssh private key (Only RSA keys in PEM format are supported)",
-			Value:  "",
-		},
-
-		mcnflag.StringFlag{
-			EnvVar: "G5K_SSH_PUBLIC_KEY",
-			Name:   "g5k-ssh-public-key",
-			Usage:  "Path of your ssh public key (Only RSA keys in AuthorizedKey format are supported) ",
-			Value:  "",
-		},
-
-		mcnflag.StringFlag{
 			EnvVar: "G5K_IMAGE",
 			Name:   "g5k-image",
 			Usage:  "Name of the image to deploy",
@@ -126,8 +110,6 @@ func (d *Driver) SetConfigFromFlags(opts drivers.DriverOptions) error {
 	d.G5kPassword = opts.String("g5k-password")
 	d.G5kSite = opts.String("g5k-site")
 	d.G5kWalltime = opts.String("g5k-walltime")
-	d.G5kSSHPrivateKeyPath = opts.String("g5k-ssh-private-key")
-	d.G5kSSHPublicKeyPath = opts.String("g5k-ssh-public-key")
 	d.G5kImage = opts.String("g5k-image")
 	d.G5kResourceProperties = opts.String("g5k-resource-properties")
 	d.G5kJobID = opts.Int("g5k-use-job-reservation")
@@ -149,11 +131,6 @@ func (d *Driver) SetConfigFromFlags(opts drivers.DriverOptions) error {
 	// site is required
 	if d.G5kSite == "" {
 		return fmt.Errorf("You must give the site you want to reserve the resources on")
-	}
-
-	// use of provided SSH key
-	if d.G5kSSHPrivateKeyPath != "" {
-		return fmt.Errorf("Use of existing SSH keys disabled for now")
 	}
 
 	return nil
@@ -237,13 +214,10 @@ func (d *Driver) PreCreateCheck() (err error) {
 		return err
 	}
 
-	// check if a SSH key pair is set
-	if d.SSHKeyPair == nil {
-		// generate a new SSH key pair
-		d.SSHKeyPair, err = ssh.NewKeyPair()
-		if err != nil {
-			return fmt.Errorf("Error when generating a new SSH key pair: %s", err.Error())
-		}
+	// generate a new SSH key pair
+	d.SSHKeyPair, err = ssh.NewKeyPair()
+	if err != nil {
+		return fmt.Errorf("Error when generating a new SSH key pair: %s", err.Error())
 	}
 
 	// submit new deployment

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -3,26 +3,22 @@ package driver
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"os"
 
 	"github.com/Spirals-Team/docker-machine-driver-g5k/api"
 
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/mcnflag"
-	"github.com/docker/machine/libmachine/mcnutils"
+	"github.com/docker/machine/libmachine/ssh"
 	"github.com/docker/machine/libmachine/state"
 )
 
 // Driver parameters
 type Driver struct {
 	*drivers.BaseDriver
-	*api.Api
 
-	G5kJobID        int
-	G5kDeploymentID string
-
+	G5kAPI                *api.Api
+	G5kJobID              int
 	G5kUsername           string
 	G5kPassword           string
 	G5kSite               string
@@ -32,6 +28,7 @@ type Driver struct {
 	G5kImage              string
 	G5kResourceProperties string
 	G5kHostToProvision    string
+	SSHKeyPair            *ssh.KeyPair `json:"-"` // remove this field from machine config
 }
 
 // NewDriver creates and returns a new instance of the driver
@@ -47,13 +44,6 @@ func NewDriver() *Driver {
 // DriverName returns the name of the driver
 func (d *Driver) DriverName() string {
 	return "g5k"
-}
-
-func (d *Driver) getAPI() *api.Api {
-	if d.Api == nil {
-		d.Api = api.NewApi(d.G5kUsername, d.G5kPassword, d.G5kSite)
-	}
-	return d.Api
 }
 
 // GetCreateFlags add command line flags to configure the driver
@@ -85,13 +75,13 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 
 		mcnflag.StringFlag{
 			Name:  "g5k-ssh-private-key",
-			Usage: "Path of your ssh private key",
-			Value: mcnutils.GetHomeDir() + "/.ssh/id_rsa",
+			Usage: "Path of your ssh private key (Only RSA keys in PEM format are supported)",
+			Value: "",
 		},
 
 		mcnflag.StringFlag{
 			Name:  "g5k-ssh-public-key",
-			Usage: "Path of your ssh public key",
+			Usage: "Path of your ssh public key (Only RSA keys in AuthorizedKey format are supported) ",
 			Value: "",
 		},
 
@@ -151,19 +141,9 @@ func (d *Driver) SetConfigFromFlags(opts drivers.DriverOptions) error {
 		return errors.New("You must give the site you want to reserve the resources on")
 	}
 
-	// check if private key exist
-	if _, err := os.Stat(d.G5kSSHPrivateKeyPath); os.IsNotExist(err) {
-		return errors.New("Your ssh private key file does not exist in : '" + d.G5kSSHPrivateKeyPath + "'")
-	}
-
-	// if the user dont specify a public key path, append .pub to the private key path
-	if d.G5kSSHPublicKeyPath == "" {
-		d.G5kSSHPublicKeyPath = d.G5kSSHPrivateKeyPath + ".pub"
-	}
-
-	// check if public key exist
-	if _, err := os.Stat(d.G5kSSHPublicKeyPath); os.IsNotExist(err) {
-		return errors.New("Your ssh public key file does not exist in : ''" + d.G5kSSHPublicKeyPath + "'")
+	// use of provided SSH key
+	if d.G5kSSHPrivateKeyPath != "" {
+		return fmt.Errorf("Use of existing SSH keys disabled for now")
 	}
 
 	return nil
@@ -211,9 +191,8 @@ func (d *Driver) GetURL() (string, error) {
 
 // GetState returns the state of the node
 func (d *Driver) GetState() (state.State, error) {
-	client := d.getAPI()
-
-	status, err := client.GetJobState(d.G5kJobID)
+	// get job state from API
+	status, err := d.G5kAPI.GetJobState(d.G5kJobID)
 	if err != nil {
 		return state.Error, err
 	}
@@ -238,66 +217,26 @@ func (d *Driver) GetState() (state.State, error) {
 
 // PreCreateCheck check parameters and submit the job to Grid5000
 func (d *Driver) PreCreateCheck() (err error) {
-	// get api client
-	client := d.getAPI()
+	// create API client
+	d.G5kAPI = api.NewApi(d.G5kUsername, d.G5kPassword, d.G5kSite)
 
-	// reading ssh public key file
-	pubkey, err := ioutil.ReadFile(d.G5kSSHPublicKeyPath)
-	if err != nil {
+	// submit new job reservation
+	if err := d.submitNewJobReservation(); err != nil {
 		return err
 	}
 
-	// skip job reservation if an ID is already set
-	if d.G5kJobID == 0 {
-		// creating a new job with 1 node
-		jobReq := api.JobRequest{
-			Resources:  fmt.Sprintf("nodes=1,walltime=%s", d.G5kWalltime),
-			Command:    "sleep 365d",
-			Properties: d.G5kResourceProperties,
-			Types:      []string{"deploy"},
-		}
-
-		// submit job
-		d.G5kJobID, err = client.SubmitJob(jobReq)
+	// check if a SSH key pair is set
+	if d.SSHKeyPair == nil {
+		// generate a new SSH key pair
+		d.SSHKeyPair, err = ssh.NewKeyPair()
 		if err != nil {
-			return err
+			return fmt.Errorf("Error when generating a new SSH key pair: %s", err.Error())
 		}
-	} else {
-		log.Infof("Skipping job reservation and using job ID '%v'", d.G5kJobID)
 	}
 
-	// wait job
-	if err = client.WaitUntilJobIsReady(d.G5kJobID); err != nil {
+	// submit new deployment
+	if err := d.submitNewDeployment(); err != nil {
 		return err
-	}
-
-	// skip deployment if provisionning only mode is used
-	if d.G5kHostToProvision == "" {
-		// get job informations
-		job, err := client.GetJob(d.G5kJobID)
-		if err != nil {
-			return err
-		}
-
-		// creating a new deployment request
-		deploymentReq := api.DeploymentRequest{
-			Nodes:       job.Nodes,
-			Environment: d.G5kImage,
-			Key:         string(pubkey),
-		}
-
-		// deploy environment
-		d.G5kDeploymentID, err = client.SubmitDeployment(deploymentReq)
-		if err != nil {
-			return err
-		}
-
-		// waiting deployment to finish (REQUIRED or you will interfere with kadeploy)
-		if err = client.WaitUntilDeploymentIsFinished(d.G5kDeploymentID); err != nil {
-			return err
-		}
-	} else {
-		log.Infof("Skipping host deployment and provisionning host '%s' only", d.G5kHostToProvision)
 	}
 
 	return nil
@@ -311,23 +250,16 @@ func (d *Driver) Create() (err error) {
 		d.BaseDriver.IPAddress = d.G5kHostToProvision
 	} else {
 		// get hostname from API
-		client := d.getAPI()
-		job, err := client.GetJob(d.G5kJobID)
+		job, err := d.G5kAPI.GetJob(d.G5kJobID)
 		if err != nil {
 			return err
 		}
 		d.BaseDriver.IPAddress = job.Nodes[0]
 	}
 
-	// Copy the SSH private key to the docker machine config folder
-	src, dst := d.G5kSSHPrivateKeyPath, d.GetSSHKeyPath()
-	if err = mcnutils.CopyFile(src, dst); err != nil {
-		return err
-	}
-
-	// change private key file mode or ssh will complain about it
-	if err := os.Chmod(dst, 0600); err != nil {
-		return err
+	// copy SSH key pair to machine directory
+	if err := d.SSHKeyPair.WriteToFile(d.GetSSHKeyPath(), d.GetSSHKeyPath()+".pub"); err != nil {
+		return fmt.Errorf("Error when copying SSH key pair to machine directory: %s", err.Error())
 	}
 
 	return nil
@@ -335,12 +267,11 @@ func (d *Driver) Create() (err error) {
 
 // Remove delete the resources reservation
 func (d *Driver) Remove() error {
-	log.Info("Killing job...")
+	log.Infof("Killing job... (id: '%d')", d.G5kJobID)
 
-	client := d.getAPI()
-	client.KillJob(d.G5kJobID)
+	// send kill job command to API
+	d.G5kAPI.KillJob(d.G5kJobID)
 
-	// We get an error if the job was already dead, which is not really an error
 	return nil
 }
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -1,8 +1,8 @@
 package driver
 
 import (
-	"errors"
 	"fmt"
+	"net"
 
 	"github.com/Spirals-Team/docker-machine-driver-g5k/api"
 
@@ -138,17 +138,17 @@ func (d *Driver) SetConfigFromFlags(opts drivers.DriverOptions) error {
 
 	// username is required
 	if d.G5kUsername == "" {
-		return errors.New("You must give your Grid5000 account username")
+		return fmt.Errorf("You must give your Grid5000 account username")
 	}
 
 	// password is required
 	if d.G5kPassword == "" {
-		return errors.New("You must give your Grid5000 account password")
+		return fmt.Errorf("You must give your Grid5000 account password")
 	}
 
 	// site is required
 	if d.G5kSite == "" {
-		return errors.New("You must give the site you want to reserve the resources on")
+		return fmt.Errorf("You must give the site you want to reserve the resources on")
 	}
 
 	// use of provided SSH key
@@ -161,7 +161,7 @@ func (d *Driver) SetConfigFromFlags(opts drivers.DriverOptions) error {
 
 // GetIP returns the ip
 func (d *Driver) GetIP() (string, error) {
-	return d.BaseDriver.IPAddress, nil
+	return d.BaseDriver.GetIP()
 }
 
 // GetMachineName returns the machine name
@@ -191,12 +191,14 @@ func (d *Driver) GetSSHUsername() string {
 
 // GetURL returns the URL of the docker daemon
 func (d *Driver) GetURL() (string, error) {
-	url, err := d.BaseDriver.GetIP()
+	// get IP address
+	ip, err := d.GetIP()
 	if err != nil {
 		return "", err
 	}
 
-	return fmt.Sprintf("tcp://%s:2376", url), nil
+	// format URL 'tcp://host:2376'
+	return fmt.Sprintf("tcp://%s", net.JoinHostPort(ip, "2376")), nil
 }
 
 // GetState returns the state of the node
@@ -287,20 +289,20 @@ func (d *Driver) Remove() error {
 
 // Kill don't do anything
 func (d *Driver) Kill() error {
-	return fmt.Errorf("Cannot kill a machine on G5K")
+	return fmt.Errorf("You can't kill a machine on Grid'5000")
 }
 
 // Start don't do anything
 func (d *Driver) Start() error {
-	return fmt.Errorf("Cannot start a machine on G5K")
+	return fmt.Errorf("You can't start a machine on Grid'5000")
 }
 
 // Stop don't do anything
 func (d *Driver) Stop() error {
-	return fmt.Errorf("Cannot stop a machine on G5K")
+	return fmt.Errorf("You can't stop a machine on Grid'5000")
 }
 
 // Restart don't do anything
 func (d *Driver) Restart() error {
-	return fmt.Errorf("Cannot restart a machine on G5K")
+	return fmt.Errorf("You can't restart a machine on Grid'5000")
 }

--- a/driver/g5k.go
+++ b/driver/g5k.go
@@ -1,0 +1,69 @@
+package driver
+
+import (
+	"fmt"
+
+	"github.com/Spirals-Team/docker-machine-driver-g5k/api"
+	"github.com/docker/machine/libmachine/log"
+)
+
+func (d *Driver) submitNewJobReservation() error {
+	// if a job ID is provided, skip job reservation
+	if d.G5kJobID != 0 {
+		log.Infof("Skipping job reservation and using job ID '%v'", d.G5kJobID)
+		return nil
+	}
+
+	// submit new Job request
+	jobID, err := d.G5kAPI.SubmitJob(api.JobRequest{
+		Resources:  fmt.Sprintf("nodes=1,walltime=%s", d.G5kWalltime),
+		Command:    "sleep 365d",
+		Properties: d.G5kResourceProperties,
+		Types:      []string{"deploy"},
+	})
+	if err != nil {
+		return fmt.Errorf("Error when submitting new job: %s", err.Error())
+	}
+
+	if err = d.G5kAPI.WaitUntilJobIsReady(jobID); err != nil {
+		return fmt.Errorf("Error when waiting for job to be running: %s", err.Error())
+	}
+
+	// job is running, keep its ID for future usage
+	d.G5kJobID = jobID
+	return nil
+}
+
+func (d *Driver) submitNewDeployment() error {
+	// if a host to provision is set, skip host deployment
+	if d.G5kHostToProvision != "" {
+		log.Infof("Skipping host deployment and provisionning host '%s' only", d.G5kHostToProvision)
+		return nil
+	}
+
+	// get job informations
+	job, err := d.G5kAPI.GetJob(d.G5kJobID)
+	if err != nil {
+		return fmt.Errorf("Error when getting job (id: '%d') informations: %s", d.G5kJobID, err.Error())
+	}
+
+	// deploy environment
+	deploymentID, err := d.G5kAPI.SubmitDeployment(api.DeploymentRequest{
+		Nodes:       job.Nodes,
+		Environment: d.G5kImage,
+		Key:         string(d.SSHKeyPair.PublicKey),
+	})
+	if err != nil {
+		return fmt.Errorf("Error when submitting new deployment: %s", err.Error())
+	}
+
+	// waiting deployment to finish (REQUIRED or you will interfere with kadeploy)
+	if err = d.G5kAPI.WaitUntilDeploymentIsFinished(deploymentID); err != nil {
+		// if deployment fail, we can't recover from this error, so we kill the job
+		log.Infof("Killing job ID '%d'...", d.G5kJobID)
+		d.G5kAPI.KillJob(d.G5kJobID)
+		return fmt.Errorf("Error when waiting for deployment to finish: %s", err.Error())
+	}
+
+	return nil
+}


### PR DESCRIPTION
PR overview:

- A unique SSH key pair (RSA 2048 bits) is now generated automatically at the machine creation. This key is not reused and deleted at the same time as the machine ;
- Removing CLI flags (--g5k-ssh-private-key, --g5k-ssh-public-key)  ;
- Allow driver configuration by environment variables (all g5k CLI flags are supported) ;
- Refactoring of Grid'5000 operations (submit of Job/Deployment), improving error messages ;
- Updating README.

Fix: #12 