### PR TITLE
Support reusing of Grid'5000 standard environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ export PATH=$PATH:$GOPATH/bin
 * `--g5k-host-to-provision` : Host to provision (host need to be already deployed)
 * `--g5k-skip-vpn-checks` : Skip the VPN client connection and DNS configuration checks (for particular use case only, you should not enable this flag in normal use)
 * `--g5k-reuse-ref-environment` : Reuse the Grid'5000 reference environment instead of re-deploying the node (it saves a lot of time)
-
+ 
 #### Flags usage
 |             Option             |          Environment         |     Default value     |
 |--------------------------------|------------------------------|-----------------------|
@@ -75,10 +75,19 @@ export PATH=$PATH:$GOPATH/bin
 You can use [OAR properties](http://oar.imag.fr/docs/2.5/user/usecases.html#using-properties) to only select a node that matches your hardware requirements.  
 If you give incorrect properties or no resource matches your request, you will get this error:
 ```bash
-Error with pre-create check: "[G5K_api] request failed: 400 Bad Request."
+...
+Error with pre-create check: "Error when submitting new job: The server returned an error (code: 400) after sending Job submission: '400 Bad Request'"
 ```
 
 More information about usage of OAR properties are available on the [Grid5000 Wiki](https://www.grid5000.fr/mediawiki/index.php/Advanced_OAR#Other_examples_using_properties).
+
+#### Grid'5000 reference environment reuse
+You can reuse the Grid'5000 reference environment (debian 9, stretch) instead of redeploying the machine.  
+If you don't need a tweaked environment, doing this will skip the deployment phase and saves you a lot of time at the machine creation.
+
+Please be aware that by default docker-machine use the `aufs` storage driver for Docker Engine on a Debian 9 (stretch) environment.  
+This is incompatible with the Grid'5000 reference environment and the `overlay2` storage driver should be used instead.  
+You will find an appropriate usage example in the following section.
 
 ### Usage examples
 An example of node provisioning reusing the Grid'5000 standard environment:
@@ -87,6 +96,7 @@ docker-machine create -d g5k \
 --g5k-username "user" \
 --g5k-password "********" \
 --g5k-site "lille" \
+--engine-storage-driver "overlay2" \
 --g5k-reuse-ref-environment \
 test-node
 ```

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ export PATH=$PATH:$GOPATH/bin
 * `--g5k-use-job-reservation` : Job ID to use (need to be an already existing job ID)
 * `--g5k-host-to-provision` : Host to provision (host need to be already deployed)
 * `--g5k-skip-vpn-checks` : Skip the VPN client connection and DNS configuration checks (for particular use case only, you should not enable this flag in normal use)
+* `--g5k-reuse-ref-environment` : Reuse the Grid'5000 reference environment instead of re-deploying the node (it saves a lot of time)
 
 #### Flags usage
 |             Option             |          Environment         |     Default value     |
@@ -63,11 +64,12 @@ export PATH=$PATH:$GOPATH/bin
 | `--g5k-password`               | `G5K_PASSWORD`               |                       |
 | `--g5k-site`                   | `G5K_SITE`                   |                       |
 | `--g5k-walltime`               | `G5K_WALLTIME`               | "1:00:00"             |
-| `--g5k-image`                  | `G5K_IMAGE`                  | "jessie-x64-min"      |
+| `--g5k-image`                  | `G5K_IMAGE`                  | "debian9-x64-std"     |
 | `--g5k-resource-properties`    | `G5K_RESOURCE_PROPERTIES`    |                       |
 | `--g5k-use-job-reservation`    | `G5K_USE_JOB_RESERVATION`    |                       |
 | `--g5k-host-to-provision`      | `G5K_HOST_TO_PROVISION`      |                       |
 | `--g5k-skip-vpn-checks`        | `G5K_SKIP_VPN_CHECKS`        | False                 |
+| `--g5k-reuse-ref-environment`  | `G5K_REUSE_REF_ENVIRONMENT`  | False                 |
 
 #### Resource properties
 You can use [OAR properties](http://oar.imag.fr/docs/2.5/user/usecases.html#using-properties) to only select a node that matches your hardware requirements.  
@@ -78,13 +80,24 @@ Error with pre-create check: "[G5K_api] request failed: 400 Bad Request."
 
 More information about usage of OAR properties are available on the [Grid5000 Wiki](https://www.grid5000.fr/mediawiki/index.php/Advanced_OAR#Other_examples_using_properties).
 
-### Provisioning examples
-An example of node provisioning:
+### Usage examples
+An example of node provisioning reusing the Grid'5000 standard environment:
 ```bash
 docker-machine create -d g5k \
 --g5k-username "user" \
 --g5k-password "********" \
 --g5k-site "lille" \
+--g5k-reuse-ref-environment \
+test-node
+```
+
+An example of node provisioning deploying the `debian9-x64-min` environment on the node:
+```bash
+docker-machine create -d g5k \
+--g5k-username "user" \
+--g5k-password "********" \
+--g5k-site "lille" \
+--g5k-image "debian9-x64-min" \
 test-node
 ```
 

--- a/README.md
+++ b/README.md
@@ -83,9 +83,10 @@ More information about usage of OAR properties are available on the [Grid5000 Wi
 
 #### Grid'5000 reference environment reuse
 You can reuse the Grid'5000 reference environment (debian 9, stretch) instead of redeploying the machine.  
-If you don't need a tweaked environment, doing this will skip the deployment phase and saves you a lot of time at the machine creation.
+Doing so will skip the node deployment phase and will save a lot of time at the machine creation.  
+If you don't need a tweaked environment or rely on some Grid'5000 services (nfs for example), you should use this option.
 
-Please be aware that by default docker-machine use the `aufs` storage driver for Docker Engine on a Debian 9 (stretch) environment.  
+Be aware that by default docker-machine use the `aufs` storage driver for Docker Engine on a Debian 9 environment.  
 This is incompatible with the Grid'5000 reference environment and the `overlay2` storage driver should be used instead.  
 You will find an appropriate usage example in the following section.
 

--- a/driver/g5k.go
+++ b/driver/g5k.go
@@ -40,7 +40,6 @@ func (d *Driver) submitNewJobReservation() error {
 
 	// if the user want to reuse the reference environment, specific actions are needed
 	if d.G5kReuseRefEnvironment {
-		log.Infof("Skipping the node deployment and reusing")
 		// remove the 'deploy' job type because we will not deploy the machine
 		jobTypes = []string{}
 		// enable sudo for current user, add public key to ssh authorized keys for root user and wait the end of the job


### PR DESCRIPTION
PR overview:

- The default image is now `debian9-x64-std` ;
- Support reusing of Grid'5000 standard environment in order to skip the deployment phase and save time ;
- Update README.

Close #23 