### PR TITLE
Allows user to add external SSH public keys to the node

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,22 +56,24 @@ export PATH=$PATH:$GOPATH/bin
 * `--g5k-host-to-provision` : Host to provision (host need to be already deployed)
 * `--g5k-skip-vpn-checks` : Skip the VPN client connection and DNS configuration checks **(don't use this flag)**
 * `--g5k-reuse-ref-environment` : Reuse the Grid'5000 reference environment instead of re-deploying the node
-* `--g5k-job-queue` : Specify the job queue (default or production only, besteffort is NOT supported)
+* `--g5k-job-queue` : Specify the job queue (besteffort queue is NOT supported)
+* `--g5k-external-ssh-public-keys` : Additional SSH public key(s) allowed to connect to the node (in authorized_keys format)
 
 #### Flags usage
-|             Option             |          Environment         |     Default value     |
-|--------------------------------|------------------------------|-----------------------|
-| `--g5k-username`               | `G5K_USERNAME`               |                       |
-| `--g5k-password`               | `G5K_PASSWORD`               |                       |
-| `--g5k-site`                   | `G5K_SITE`                   |                       |
-| `--g5k-walltime`               | `G5K_WALLTIME`               | "1:00:00"             |
-| `--g5k-image`                  | `G5K_IMAGE`                  | "debian9-x64-std"     |
-| `--g5k-resource-properties`    | `G5K_RESOURCE_PROPERTIES`    |                       |
-| `--g5k-use-job-reservation`    | `G5K_USE_JOB_RESERVATION`    |                       |
-| `--g5k-host-to-provision`      | `G5K_HOST_TO_PROVISION`      |                       |
-| `--g5k-skip-vpn-checks`        | `G5K_SKIP_VPN_CHECKS`        | False                 |
-| `--g5k-reuse-ref-environment`  | `G5K_REUSE_REF_ENVIRONMENT`  | False                 |
-| `--g5k-job-queue`              | `G5K_JOB_QUEUE`              | "default"             |
+|             Option               |          Environment           |     Default value     |
+|----------------------------------|--------------------------------|-----------------------|
+| `--g5k-username`                 | `G5K_USERNAME`                 |                       |
+| `--g5k-password`                 | `G5K_PASSWORD`                 |                       |
+| `--g5k-site`                     | `G5K_SITE`                     |                       |
+| `--g5k-walltime`                 | `G5K_WALLTIME`                 | "1:00:00"             |
+| `--g5k-image`                    | `G5K_IMAGE`                    | "debian9-x64-std"     |
+| `--g5k-resource-properties`      | `G5K_RESOURCE_PROPERTIES`      |                       |
+| `--g5k-use-job-reservation`      | `G5K_USE_JOB_RESERVATION`      |                       |
+| `--g5k-host-to-provision`        | `G5K_HOST_TO_PROVISION`        |                       |
+| `--g5k-skip-vpn-checks`          | `G5K_SKIP_VPN_CHECKS`          | False                 |
+| `--g5k-reuse-ref-environment`    | `G5K_REUSE_REF_ENVIRONMENT`    | False                 |
+| `--g5k-job-queue`                | `G5K_JOB_QUEUE`                | "default"             |
+| `--g5k-external-ssh-public-keys` | `G5K_EXTERNAL_SSH_PUBLIC_KEYS` |                       |
 
 #### Resource properties
 You can use [OAR properties](http://oar.imag.fr/docs/2.5/user/usecases.html#using-properties) to only select a node that matches your hardware requirements.  
@@ -153,3 +155,13 @@ docker-machine create -d g5k \
 --g5k-host-to-provision "chinqchint-xx.lille.grid5000.fr" \
 test-node
 ``` 
+
+An example adding multiple external SSH keys (your keys can be of any supported format, and may be longer than the following example):
+```bash
+docker-machine create -d g5k \
+--g5k-username "user" \
+--g5k-password "********" \
+--g5k-site "lille" \
+--g5k-external-ssh-public-keys "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFLs3JzUYn7LbHE+SzJNoMvYbasnhjlen0k6dFs801DT test-ed25519" \
+--g5k-external-ssh-public-keys "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQC5qQt/nzGW19uCb9CDVEvP93LZ2mu3rd7drPP1nLf1pzLwlL2U2ksfwDCjMWU0P7KA6tB4scI+4dhxj07t0Z8g4TsMGYhbG0kjf7tWN73DombB4h/zobo2GvVoMg0NBLTP4peXLYAEofTYc0g7OWtJicAzLwcMzHsitDjjBwCKHQ== test-rsa" \
+```

--- a/driver/g5k.go
+++ b/driver/g5k.go
@@ -32,10 +32,12 @@ func (d *Driver) generateSSHAuthorizedKeys() string {
 	var authorizedKeys strings.Builder
 
 	// add ephemeral key
-	authorizedKeys.WriteString(string(d.EphemeralSSHKeyPair.PublicKey) + "\n")
+	authorizedKeys.WriteString("# docker-machine driver g5k - ephemeral key\n")
+	authorizedKeys.WriteString(string(d.EphemeralSSHKeyPair.PublicKey))
 
 	// add external key(s)
-	for _, externalPubKey := range d.ExternalSSHPublicKeys {
+	for index, externalPubKey := range d.ExternalSSHPublicKeys {
+		authorizedKeys.WriteString(fmt.Sprintf("# docker-machine driver g5k - additional key %d\n", index))
 		authorizedKeys.WriteString(externalPubKey + "\n")
 	}
 

--- a/driver/g5k.go
+++ b/driver/g5k.go
@@ -60,7 +60,7 @@ func (d *Driver) submitNewJobReservation() error {
 		// remove the 'deploy' job type because we will not deploy the machine
 		jobTypes = []string{}
 		// enable sudo for current user, add public key to ssh authorized keys for root user and wait the end of the job
-		jobCommand = `sudo-g5k && sudo /bin/sh -c 'echo "` + d.generateSSHAuthorizedKeys() + `" >>/root/.ssh/authorized_keys' && sleep 365d`
+		jobCommand = `sudo-g5k && sudo /bin/sh -c 'echo -e "` + d.generateSSHAuthorizedKeys() + `" >>/root/.ssh/authorized_keys' && sleep 365d`
 	}
 
 	// submit new Job request

--- a/driver/g5k.go
+++ b/driver/g5k.go
@@ -33,15 +33,15 @@ func (d *Driver) generateSSHAuthorizedKeys() string {
 
 	// add ephemeral key
 	authorizedKeysEntries = append(authorizedKeysEntries, "# docker-machine driver g5k - ephemeral key")
-	authorizedKeysEntries = append(authorizedKeysEntries, string(d.EphemeralSSHKeyPair.PublicKey))
+	authorizedKeysEntries = append(authorizedKeysEntries, strings.TrimSpace(string(d.EphemeralSSHKeyPair.PublicKey)))
 
 	// add external key(s)
 	for index, externalPubKey := range d.ExternalSSHPublicKeys {
 		authorizedKeysEntries = append(authorizedKeysEntries, fmt.Sprintf("# docker-machine driver g5k - additional key %d", index))
-		authorizedKeysEntries = append(authorizedKeysEntries, externalPubKey)
+		authorizedKeysEntries = append(authorizedKeysEntries, strings.TrimSpace(externalPubKey))
 	}
 
-	return strings.Join(authorizedKeysEntries, "\n")
+	return strings.Join(authorizedKeysEntries, "\n") + "\n"
 }
 
 func (d *Driver) submitNewJobReservation() error {
@@ -60,7 +60,7 @@ func (d *Driver) submitNewJobReservation() error {
 		// remove the 'deploy' job type because we will not deploy the machine
 		jobTypes = []string{}
 		// enable sudo for current user, add public key to ssh authorized keys for root user and wait the end of the job
-		jobCommand = `sudo-g5k && echo -e "` + d.generateSSHAuthorizedKeys() + `" |sudo tee -a /root/.ssh/authorized_keys >/dev/null && sleep 365d`
+		jobCommand = `sudo-g5k && echo -n "` + d.generateSSHAuthorizedKeys() + `" |sudo tee -a /root/.ssh/authorized_keys >/dev/null && sleep 365d`
 	}
 
 	// submit new Job request


### PR DESCRIPTION
PR overview:

- Add cli flag `g5k-external-ssh-public-keys` to specify additional SSH public keys allowed to connect to the node ;
- Blacklist the `besteffort` queue instead of whitelisting supported ones.