### PR TITLE
Update supported CPU architectures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
     - GIMME_OS=linux GIMME_ARCH=386
     # MacOS
     - GIMME_OS=darwin GIMME_ARCH=amd64
-    - GIMME_OS=darwin GIMME_ARCH=386
     # Windows
     - GIMME_OS=windows GIMME_ARCH=amd64
     - GIMME_OS=windows GIMME_ARCH=386

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ env:
     # Linux
     - GIMME_OS=linux GIMME_ARCH=amd64
     - GIMME_OS=linux GIMME_ARCH=386
+    - GIMME_OS=linux GIMME_ARCH=arm
+    - GIMME_OS=linux GIMME_ARCH=arm64
     # MacOS
     - GIMME_OS=darwin GIMME_ARCH=amd64
     # Windows


### PR DESCRIPTION
PR overview:
- Remove the build of 32bit MacOS executables ;
- Add the build of arm (armhf) and arm64 (aarch64) executables for Linux.

We now provides binaries of the driver for the same architectures as the [Docker machine](https://github.com/docker/machine/releases).