### PR TITLE
Update std env and Golang versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.13
 
     working_directory: /go/src/github.com/Spirals-Team/docker-machine-driver-g5k
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -17,7 +17,7 @@ import (
 )
 
 // g5kReferenceEnvironment is the name of the reference environment automatically deployed on the node by Grid'5000
-const g5kReferenceEnvironmentName string = "debian9-x64-std"
+const g5kReferenceEnvironmentName string = "debian10-x64-std"
 
 // Driver parameters
 type Driver struct {


### PR DESCRIPTION
PR overview:
- Update std environment image to Debian 10 (`debian10-x64-std`) ;
- Update to Golang v1.13 for the CircleCI builds (tests + releases).